### PR TITLE
Implement rubik's cube representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ TODO: complete with all used approaches
 
 This is what is left to be done ordered by priority:
 
-- [ ] Implement represantion of rubik's cube
+- [X] Implement represantion of rubik's cube
 - [ ] Preprocess transformations
 - [ ] Implement Dijkstra
 - [ ] Implement A* with some score function

--- a/README.md
+++ b/README.md
@@ -83,3 +83,4 @@ This is what is left to be done ordered by priority:
 - [ ] Implement proper CLI
   - [ ] Define protocol of input and output
   - [ ] Define important options and arguments
+- [ ] Document `Cube`'s API

--- a/src/cube/cube.rs
+++ b/src/cube/cube.rs
@@ -1,14 +1,17 @@
+pub type Coordinate = (usize, usize, usize);
+pub type CubeState = [[[u8; 3]; 3]; 6];
+
 pub struct Cube {
     pub transformations: i64,
 
-    array: [[[u8; 3]; 3]; 6],
+    state: CubeState,
 }
 
 impl Cube {
     pub fn solved() -> Self {
         Self {
             transformations: 0,
-            array: [
+            state: [
                 [[0; 3]; 3],
                 [[1; 3]; 3],
                 [[2; 3]; 3],
@@ -30,7 +33,7 @@ mod tests {
         for face in 0..6 {
             for i in 0..3 {
                 for j in 0..3 {
-                    assert_eq!(solved_cube.array[face][i][j], face as u8);
+                    assert_eq!(solved_cube.state[face][i][j], face as u8);
                 }
             }
         }

--- a/src/cube/cube.rs
+++ b/src/cube/cube.rs
@@ -1,0 +1,39 @@
+pub struct Cube {
+    pub transformations: i64,
+
+    array: [[[u8; 3]; 3]; 6],
+}
+
+impl Cube {
+    pub fn solved() -> Self {
+        Self {
+            transformations: 0,
+            array: [
+                [[0; 3]; 3],
+                [[1; 3]; 3],
+                [[2; 3]; 3],
+                [[3; 3]; 3],
+                [[4; 3]; 3],
+                [[5; 3]; 3],
+            ],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn solved_cube_is_solved_and_untouched() {
+        let solved_cube = Cube::solved();
+        for face in 0..6 {
+            for i in 0..3 {
+                for j in 0..3 {
+                    assert_eq!(solved_cube.array[face][i][j], face as u8);
+                }
+            }
+        }
+        assert_eq!(solved_cube.transformations, 0);
+    }
+}

--- a/src/cube/cube.rs
+++ b/src/cube/cube.rs
@@ -2,7 +2,7 @@ pub type Coordinate = (usize, usize, usize);
 pub type CubeState = [[[u8; 3]; 3]; 6];
 
 pub struct Cube {
-    pub transformations: i64,
+    pub transformations: u32,
 
     state: CubeState,
 }

--- a/src/cube/mod.rs
+++ b/src/cube/mod.rs
@@ -1,0 +1,3 @@
+mod cube;
+
+pub use cube::Cube;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod cube;
+
 #[cfg(test)]
 mod tests {
     #[test]


### PR DESCRIPTION
Implementation of the rubik's cube representation according to the README description.
A each face of the rubiks cube is represented by a 3x3 array. Since a cube has 6 faces, we store a cube representation in a 6x3x3 array.

Also added a task to track the documentation of the api in the `cube.rs` file.